### PR TITLE
fix: update peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
 		"typescript": "^5.7.2"
 	},
 	"peerDependencies": {
-		"typedoc": "~0.26.0 || ~0.27.0"
+		"typedoc": ">=0.26.0 <0.28.0"
 	}
 }


### PR DESCRIPTION
This should fix the issue so that anything in the .26 and .27 versions work.