### PR TITLE
fix: invalid `main`/`types` paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "@shipgirl/typedoc-plugin-versions",
 	"version": "0.3.1",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "./index.js",
+	"types": "./index.d.ts",
 	"type": "module",
 	"scripts": {
 		"lint": "prettier -c .",


### PR DESCRIPTION
This PR fixes the `main` and `types` paths in the package.json.
The current paths are invalid because there is no `dist` folder in the final package.

These dist paths were causing `DEP0151` warnings on newer versions of node, like the one below.
```
(node:30780) [DEP0151] DeprecationWarning: Package C:\dev\oss\eolib-ts\node_modules\@shipgirl\typedoc-plugin-versions\ has a "main" field set to "dist/index.js", excluding the full filename and extension to the resolved file at "index.js", imported from C:\dev\oss\eolib-ts\node_modules\typedoc\dist\lib\utils\plugins.js.
 Automatic extension resolution of the "main" field is deprecated for ES modules.
```