### PR TITLE
chore: regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@shipgirl/typedoc-plugin-versions",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@shipgirl/typedoc-plugin-versions",
-			"version": "0.3.0",
+			"version": "0.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^11.2.0",
@@ -38,7 +38,7 @@
 				"npm": ">=6.0.0"
 			},
 			"peerDependencies": {
-				"typedoc": "~0.26.0 || ~0.27.0"
+				"typedoc": ">=0.26.0 <0.29.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {


### PR DESCRIPTION
This PR regenerates the package-lock, which is currently out of sync with package.json.