### PR TITLE
fix: add 0.75rem margin below version selector

### DIFF
--- a/src/etc/hooks.tsx
+++ b/src/etc/hooks.tsx
@@ -59,7 +59,7 @@ export function injectSelectHtml(
 		app.renderer.hooks.on('head.end', () => (
 			<style>{`
 				.tsd-ext-version-select .settings-label {
-					margin: 0.75rem 0.75rem 0 0;
+					margin: 0.75rem 0.75rem 0.75rem 0;
 				}
 			`}</style>
 		));


### PR DESCRIPTION
This PR adds a 0.75rem margin below the injected version selector.

### Before

![image](https://github.com/user-attachments/assets/dcc86f73-6ed2-4964-b869-11eaec1022d1)

### After

![image](https://github.com/user-attachments/assets/460f483a-f708-4f9e-b552-04bd056d490e)
